### PR TITLE
Server pod fixes

### DIFF
--- a/assets/translations/en-us.yaml
+++ b/assets/translations/en-us.yaml
@@ -7601,8 +7601,20 @@ verrazzano:
       overrideDistributionStrategy: Overrides Distribution Strategy
       overridesConfigMap: Overrides Config Map Name
       restartVersion: Restart Version
+      serverPod:
+        shutdown:
+          ignoreSession: Ignore Sessions
+          shutdownType: Shutdown Type
+          timeoutSeconds: Timeout Seconds
+          waitForAllSessions: Wait for All Sessions
       serverStartPolicy: Server Start Policy
       serverStartState: Server Start State
+
+    ####################################
+    ### verrazzano.weblogic.messages ###
+    ####################################
+    messages:
+      noAuxiliaryImages: No auxiliary images defined
 
     ################################
     ### verrazzano.weblogic.tabs ###
@@ -8245,16 +8257,6 @@ verrazzano:
         precreateService: Pre-Create Services
         restartVersion: Restart Version
         serverName: Server Name
-        serverPod:
-          priorityClassName: Priority Class Name
-          restartPolicy: Restart Policy
-          runtimeClassName: Runtime Class Name
-          serviceAccountName: Service Account Name
-          shutdown:
-            ignoreSession: Ignore Sessions
-            shutdownType: Shutdown Type
-            timeoutSeconds: Timeout Seconds
-            waitForAllSessions: Wait for All Sessions
         serverStartPolicy: Server Start Policy
         serverStartState: Server Start State
         webLogicCredentialsSecret: WebLogic Domain Credentials Secret
@@ -8277,7 +8279,6 @@ verrazzano:
         volumeMounts: Volume Mounts
         wdtTimeouts: WebLogic Deploy Tooling Online Timeouts
       values:
-        noAuxiliaryImages: No Auxiliary Images Defined
         types:
           domainHomeSourceType:
             domainInPV: Domain in Persistent Volume

--- a/components/verrazzano/AddNamedElement.vue
+++ b/components/verrazzano/AddNamedElement.vue
@@ -2,7 +2,6 @@
 // Added by Verrazzano
 import LabeledInput from '@/components/form/LabeledInput';
 import VerrazzanoHelper from '@/mixins/verrazzano/verrazzano-helper';
-import { _VIEW } from '@/config/query-params';
 
 export default {
   name:       'AddNamedElement',
@@ -76,12 +75,6 @@ export default {
 
   mounted() {
     this.newName = this.getUnusedName();
-  },
-
-  computed: {
-    isView() {
-      return this.mode === _VIEW;
-    },
   },
 
   watch: {

--- a/components/verrazzano/TabDeleteButton.vue
+++ b/components/verrazzano/TabDeleteButton.vue
@@ -1,13 +1,12 @@
 <script>
 // Added by Verrazzano
-import CreateEditView from '@/mixins/create-edit-view';
+import { _VIEW } from '@/config/query-params';
 
 // this button fits next to the header at the top of TreeTabbed content
 
 export default {
-  name:   'TabDeleteButton',
-  mixins: [CreateEditView],
-  props:  {
+  name:  'TabDeleteButton',
+  props: {
     mode: {
       type:     String,
       required: true,
@@ -15,6 +14,12 @@ export default {
     elementName: {
       type:     String,
       required: true,
+    },
+  },
+
+  computed: {
+    isView() {
+      return this.mode === _VIEW;
     },
   },
 };

--- a/components/verrazzano/TabDeleteButton.vue
+++ b/components/verrazzano/TabDeleteButton.vue
@@ -7,10 +7,6 @@ import { _VIEW } from '@/config/query-params';
 export default {
   name:       'TabDeleteButton',
   props:      {
-    value: {
-      type:    Array,
-      default: () => ([])
-    },
     mode: {
       type:     String,
       required: true,

--- a/components/verrazzano/TabDeleteButton.vue
+++ b/components/verrazzano/TabDeleteButton.vue
@@ -1,12 +1,13 @@
 <script>
 // Added by Verrazzano
-import { _VIEW } from '@/config/query-params';
+import CreateEditView from '@/mixins/create-edit-view';
 
 // this button fits next to the header at the top of TreeTabbed content
 
 export default {
-  name:       'TabDeleteButton',
-  props:      {
+  name:   'TabDeleteButton',
+  mixins: [CreateEditView],
+  props:  {
     mode: {
       type:     String,
       required: true,
@@ -14,12 +15,6 @@ export default {
     elementName: {
       type:     String,
       required: true,
-    },
-  },
-
-  computed: {
-    isView() {
-      return this.mode === _VIEW;
     },
   },
 };

--- a/edit/core.oam.dev.component/VerrazzanoHelidonWorkload/index.vue
+++ b/edit/core.oam.dev.component/VerrazzanoHelidonWorkload/index.vue
@@ -308,7 +308,7 @@ export default {
               <LabeledSelect
                 :value="getField('spec.workload.spec.deploymentTemplate.podSpec.restartPolicy')"
                 :mode="mode"
-                :label="t('verrazzano.VerrazzanoWebLogicWorkload.config.fields.serverPod.restartPolicy')"
+                :label="t('verrazzano.common.fields.podSpec.restartPolicy')"
                 :placeholder="getNotSetPlaceholder(value, 'restartPolicy')"
                 :options="[
                   {
@@ -343,7 +343,7 @@ export default {
               <LabeledInput
                 :value="getField('spec.workload.spec.deploymentTemplate.podSpec.priorityClassName')"
                 :mode="mode"
-                :label="t('verrazzano.VerrazzanoWebLogicWorkload.config.fields.serverPod.priorityClassName')"
+                :label="t('verrazzano.common.fields.podSpec.priorityClassName')"
                 :placeholder="getNotSetPlaceholder(value, 'priorityClassName')"
                 @input="setField('spec.workload.spec.deploymentTemplate.podSpec.priorityClassName', $event)"
               />
@@ -352,7 +352,7 @@ export default {
               <LabeledInput
                 :value="getField('spec.workload.spec.deploymentTemplate.podSpec.runtimeClassName')"
                 :mode="mode"
-                :label="t('verrazzano.VerrazzanoWebLogicWorkload.config.fields.serverPod.runtimeClassName')"
+                :label="t('verrazzano.common.fields.podSpec.runtimeClassName')"
                 :placeholder="getNotSetPlaceholder(value, 'runtimeClassName')"
                 @input="setField('spec.workload.spec.deploymentTemplate.podSpec.runtimeClassName', $event)"
               />

--- a/edit/core.oam.dev.component/VerrazzanoWebLogicWorkload/AuxiliaryImage.vue
+++ b/edit/core.oam.dev.component/VerrazzanoWebLogicWorkload/AuxiliaryImage.vue
@@ -3,6 +3,7 @@
 import LabeledInput from '@/components/form/LabeledInput';
 import LabeledSelect from '@/components/form/LabeledSelect';
 import NotSetPlaceholder from '@/mixins/verrazzano/not-set-placeholder';
+import VerrazzanoHelper from '@/mixins/verrazzano/verrazzano-helper';
 
 export default {
   name:       'AuxiliaryImage',
@@ -10,7 +11,7 @@ export default {
     LabeledInput,
     LabeledSelect
   },
-  mixins: [NotSetPlaceholder],
+  mixins: [NotSetPlaceholder, VerrazzanoHelper],
   props:  {
     value: {
       type:    Object,
@@ -47,20 +48,22 @@ export default {
     <div class="row">
       <div class="col span-9">
         <LabeledInput
-          v-model="value.image"
+          :value="getField('image')"
           :mode="mode"
           :label="t('verrazzano.VerrazzanoWebLogicWorkload.config.fields.auxiliaryImage')"
           :placeholder="getNotSetPlaceholder(value, 'image')"
+          @input="setField('image', $event)"
         />
       </div>
       <div class="col span-3">
         <LabeledSelect
-          v-model="value.imagePullPolicy"
+          :value="getField('imagePullPolicy')"
           :mode="mode"
           :label="t('verrazzano.components.config.fields.imagePullPolicy')"
           :options="imagePullPolicyOptions"
           option-key="value"
           :placeholder="getNotSetPlaceholder(value, 'imagePullPolicy')"
+          @input="setField('imagePullPolicy', $event)"
         />
       </div>
     </div>
@@ -68,18 +71,20 @@ export default {
     <div class="row">
       <div class="col span-3">
         <LabeledInput
-          v-model="value.volume"
+          :value="getField('volume')"
           :mode="mode"
           :label="t('verrazzano.VerrazzanoWebLogicWorkload.config.fields.auxiliaryImageVolumeReference')"
           :placeholder="getNotSetPlaceholder(value, 'volume')"
+          @input="setField('volume', $event)"
         />
       </div>
       <div class="col span-9">
         <LabeledInput
-          v-model="value.command"
+          :value="getField('command')"
           :mode="mode"
           :label="t('verrazzano.VerrazzanoWebLogicWorkload.config.fields.auxiliaryImageCommand')"
           :placeholder="getNotSetPlaceholder(value, 'command')"
+          @input="setFieldIfNotEmpty('command', $event)"
         />
       </div>
     </div>

--- a/edit/core.oam.dev.component/VerrazzanoWebLogicWorkload/AuxiliaryImage.vue
+++ b/edit/core.oam.dev.component/VerrazzanoWebLogicWorkload/AuxiliaryImage.vue
@@ -52,7 +52,7 @@ export default {
           :mode="mode"
           :label="t('verrazzano.VerrazzanoWebLogicWorkload.config.fields.auxiliaryImage')"
           :placeholder="getNotSetPlaceholder(value, 'image')"
-          @input="setField('image', $event)"
+          @input="setFieldIfNotEmpty('image', $event)"
         />
       </div>
       <div class="col span-3">
@@ -63,7 +63,7 @@ export default {
           :options="imagePullPolicyOptions"
           option-key="value"
           :placeholder="getNotSetPlaceholder(value, 'imagePullPolicy')"
-          @input="setField('imagePullPolicy', $event)"
+          @input="setFieldIfNotEmpty('imagePullPolicy', $event)"
         />
       </div>
     </div>
@@ -75,7 +75,7 @@ export default {
           :mode="mode"
           :label="t('verrazzano.VerrazzanoWebLogicWorkload.config.fields.auxiliaryImageVolumeReference')"
           :placeholder="getNotSetPlaceholder(value, 'volume')"
-          @input="setField('volume', $event)"
+          @input="setFieldIfNotEmpty('volume', $event)"
         />
       </div>
       <div class="col span-9">

--- a/edit/core.oam.dev.component/VerrazzanoWebLogicWorkload/AuxiliaryImages.vue
+++ b/edit/core.oam.dev.component/VerrazzanoWebLogicWorkload/AuxiliaryImages.vue
@@ -4,7 +4,6 @@ import AuxiliaryImage from '@/edit/core.oam.dev.component/VerrazzanoWebLogicWork
 import ArrayListGrouped from '@/components/form/ArrayListGrouped';
 import DynamicListHelper from '@/mixins/verrazzano/dynamic-list-helper';
 import VerrazzanoHelper from '@/mixins/verrazzano/verrazzano-helper';
-import { _VIEW } from '@/config/query-params';
 
 export default {
   name:       'AuxiliaryImages',
@@ -37,13 +36,6 @@ export default {
     getRootFieldName() {
       return this.rootFieldName;
     }
-  },
-
-  computed: {
-    isView() {
-      // used by showEmptyListMessage
-      return this.mode === _VIEW;
-    },
   },
 };
 </script>

--- a/edit/core.oam.dev.component/VerrazzanoWebLogicWorkload/AuxiliaryImages.vue
+++ b/edit/core.oam.dev.component/VerrazzanoWebLogicWorkload/AuxiliaryImages.vue
@@ -5,6 +5,7 @@ import ArrayListGrouped from '@/components/form/ArrayListGrouped';
 import { randomStr } from '@/utils/string';
 import debounce from 'lodash/debounce';
 import VerrazzanoHelper from '@/mixins/verrazzano/verrazzano-helper';
+import { _VIEW } from '@/config/query-params';
 
 export default {
   name:       'AuxiliaryImages',
@@ -66,6 +67,14 @@ export default {
       this.queueUpdate();
     }
   },
+
+  computed: {
+    isView() {
+      // used by showEmptyListMessage
+      return this.mode === _VIEW;
+    },
+  },
+
   created() {
     this.queueUpdate = debounce(this.update, 500);
   }
@@ -80,6 +89,7 @@ export default {
       :default-add-value="{ }"
       :add-label="t('verrazzano.weblogic.buttons.addAuxiliaryImage')"
       @add="addImage()"
+      @input="$emit('input', value)"
     >
       <template #remove-button="removeProps">
         <button
@@ -100,8 +110,8 @@ export default {
         />
       </template>
     </ArrayListGrouped>
-    <div v-if="showEmptyListMessage('auxiliaryImages')">
-      {{ t('verrazzano.VerrazzanoWebLogicWorkload.config.values.noAuxiliaryImages') }}
+    <div v-if="showEmptyListMessage(rootFieldName)">
+      {{ t('verrazzano.weblogic.messages.noAuxiliaryImages') }}
     </div>
   </div>
 </template>

--- a/edit/core.oam.dev.component/VerrazzanoWebLogicWorkload/ClustersTab/ClusterTab.vue
+++ b/edit/core.oam.dev.component/VerrazzanoWebLogicWorkload/ClustersTab/ClusterTab.vue
@@ -2,7 +2,6 @@
 // Added by Verrazzano
 import Checkbox from '@/components/form/Checkbox';
 import ClusterService from '@/edit/core.oam.dev.component/VerrazzanoWebLogicWorkload/ClustersTab/ClusterService';
-import DynamicListHelper from '@/mixins/verrazzano/dynamic-list-helper';
 import LabeledInput from '@/components/form/LabeledInput';
 import LabeledSelect from '@/components/form/LabeledSelect';
 import ServerPodTab from '@/edit/core.oam.dev.component/VerrazzanoWebLogicWorkload/ServerPodTab';
@@ -24,7 +23,7 @@ export default {
     TabDeleteButton,
     TreeTab
   },
-  mixins: [WeblogicWorkloadHelper, DynamicListHelper],
+  mixins: [WeblogicWorkloadHelper],
   props:  {
     // the cluster object
     value: {
@@ -46,9 +45,6 @@ export default {
   },
 
   methods: {
-    getRootFieldName() {
-      return 'clusters';
-    },
     clusterKey(cluster) {
       return this.createTabKey('cluster', cluster.clusterName);
     },

--- a/edit/core.oam.dev.component/VerrazzanoWebLogicWorkload/ClustersTab/ClusterTab.vue
+++ b/edit/core.oam.dev.component/VerrazzanoWebLogicWorkload/ClustersTab/ClusterTab.vue
@@ -9,7 +9,6 @@ import ServerService from '@/edit/core.oam.dev.component/VerrazzanoWebLogicWorkl
 import TabDeleteButton from '@/components/verrazzano/TabDeleteButton';
 import TreeTab from '@/components/verrazzano/TreeTabbed/TreeTab';
 import WeblogicWorkloadHelper from '@/mixins/verrazzano/weblogic-workload-helper';
-import { _VIEW } from '@/config/query-params';
 
 export default {
   name:       'ClusterTab',
@@ -47,12 +46,6 @@ export default {
   methods: {
     clusterKey(cluster) {
       return this.createTabKey('cluster', cluster.clusterName);
-    },
-  },
-
-  computed: {
-    isView() {
-      return this.mode === _VIEW;
     },
   },
 };

--- a/edit/core.oam.dev.component/VerrazzanoWebLogicWorkload/ClustersTab/index.vue
+++ b/edit/core.oam.dev.component/VerrazzanoWebLogicWorkload/ClustersTab/index.vue
@@ -5,7 +5,6 @@ import ClusterTab from '@/edit/core.oam.dev.component/VerrazzanoWebLogicWorkload
 import DynamicListHelper from '@/mixins/verrazzano/dynamic-list-helper';
 import TreeTab from '@/components/verrazzano/TreeTabbed/TreeTab';
 import WeblogicWorkloadHelper from '@/mixins/verrazzano/weblogic-workload-helper';
-import { _VIEW } from '@/config/query-params';
 
 export default {
   name:       'ClustersTab',
@@ -39,12 +38,6 @@ export default {
     getRootFieldName() {
       return 'clusters';
     }
-  },
-
-  computed: {
-    isView() {
-      return this.mode === _VIEW;
-    },
   },
 };
 </script>

--- a/edit/core.oam.dev.component/VerrazzanoWebLogicWorkload/ManagedServersTab/ManagedServerTab.vue
+++ b/edit/core.oam.dev.component/VerrazzanoWebLogicWorkload/ManagedServersTab/ManagedServerTab.vue
@@ -1,6 +1,5 @@
 <script>
 // Added by Verrazzano
-import DynamicListHelper from '@/mixins/verrazzano/dynamic-list-helper';
 import LabeledInput from '@/components/form/LabeledInput';
 import LabeledSelect from '@/components/form/LabeledSelect';
 import ServerPodTab from '@/edit/core.oam.dev.component/VerrazzanoWebLogicWorkload/ServerPodTab';
@@ -19,7 +18,7 @@ export default {
     TabDeleteButton,
     TreeTab,
   },
-  mixins: [WeblogicWorkloadHelper, DynamicListHelper],
+  mixins: [WeblogicWorkloadHelper],
   props:  {
     value: {
       type:    Object,
@@ -40,9 +39,6 @@ export default {
   },
 
   methods: {
-    getRootFieldName() {
-      return 'managedServers';
-    },
     serverKey(server) {
       return this.createTabKey('managedServer', server['serverName']);
     }

--- a/edit/core.oam.dev.component/VerrazzanoWebLogicWorkload/ServerPodTab.vue
+++ b/edit/core.oam.dev.component/VerrazzanoWebLogicWorkload/ServerPodTab.vue
@@ -104,7 +104,7 @@ export default {
       <div class="col span-3">
         <LabeledSelect
           :value="getField('serviceAccountName')"
-          :label="t('verrazzano.VerrazzanoWebLogicWorkload.config.fields.serverPod.serviceAccountName')"
+          :label="t('verrazzano.common.fields.podSpec.serviceAccountName')"
           :placeholder="getNotSetPlaceholder(value, 'serviceAccountName')"
           :options="serviceAccounts"
           :mode="mode"
@@ -121,7 +121,7 @@ export default {
           option-key="value"
           option-label="label"
           :placeholder="getNotSetPlaceholder(value, 'restartPolicy')"
-          :label="t('verrazzano.VerrazzanoWebLogicWorkload.config.fields.serverPod.restartPolicy')"
+          :label="t('verrazzano.common.fields.podSpec.restartPolicy')"
           @input="setField('restartPolicy', $event)"
         />
       </div>
@@ -129,7 +129,7 @@ export default {
         <LabeledInput
           :value="getField('priorityClassName')"
           :mode="mode"
-          :label="t('verrazzano.VerrazzanoWebLogicWorkload.config.fields.serverPod.priorityClassName')"
+          :label="t('verrazzano.common.fields.podSpec.priorityClassName')"
           :placeholder="getNotSetPlaceholder(value, 'priorityClassName')"
           @input="setField('priorityClassName', $event)"
         />
@@ -138,7 +138,7 @@ export default {
         <LabeledInput
           :value="getField('runtimeClassName')"
           :mode="mode"
-          :label="t('verrazzano.VerrazzanoWebLogicWorkload.config.fields.serverPod.runtimeClassName')"
+          :label="t('verrazzano.common.fields.podSpec.runtimeClassName')"
           :placeholder="getNotSetPlaceholder(value, 'runtimeClassName')"
           @input="setField('runtimeClassName', $event)"
         />
@@ -261,9 +261,10 @@ export default {
         :name="createTabKey(navPrefix, 'auxiliaryImages')"
       >
         <AuxiliaryImages
-          v-model="value"
+          :value="value"
           :mode="mode"
           :namespaced-object="namespacedObject"
+          @input="$emit('input', value)"
         />
       </TreeTab>
 
@@ -292,10 +293,11 @@ export default {
         :name="createTabKey(navPrefix, 'envVariables')"
       >
         <EnvironmentVariables
-          v-model="value"
+          :value="value"
           :mode="mode"
-          :namespaced-object="value"
+          :namespaced-object="namespacedObject"
           :enable-env-from-options="false"
+          @input="$emit('input', value)"
         />
       </TreeTab>
     </template>

--- a/edit/core.oam.dev.component/VerrazzanoWebLogicWorkload/ServerPodTab.vue
+++ b/edit/core.oam.dev.component/VerrazzanoWebLogicWorkload/ServerPodTab.vue
@@ -110,7 +110,7 @@ export default {
           :mode="mode"
           option-label="metadata.name"
           :reduce="serviceAccount => serviceAccount.metadata.name"
-          @input="setField('serviceAccountName', $event)"
+          @input="setFieldIfNotEmpty('serviceAccountName', $event)"
         />
       </div>
       <div class="col span-3">
@@ -122,7 +122,7 @@ export default {
           option-label="label"
           :placeholder="getNotSetPlaceholder(value, 'restartPolicy')"
           :label="t('verrazzano.common.fields.podSpec.restartPolicy')"
-          @input="setField('restartPolicy', $event)"
+          @input="setFieldIfNotEmpty('restartPolicy', $event)"
         />
       </div>
       <div class="col span-3">
@@ -131,7 +131,7 @@ export default {
           :mode="mode"
           :label="t('verrazzano.common.fields.podSpec.priorityClassName')"
           :placeholder="getNotSetPlaceholder(value, 'priorityClassName')"
-          @input="setField('priorityClassName', $event)"
+          @input="setFieldIfNotEmpty('priorityClassName', $event)"
         />
       </div>
       <div class="col span-3">
@@ -140,7 +140,7 @@ export default {
           :mode="mode"
           :label="t('verrazzano.common.fields.podSpec.runtimeClassName')"
           :placeholder="getNotSetPlaceholder(value, 'runtimeClassName')"
-          @input="setField('runtimeClassName', $event)"
+          @input="setFieldIfNotEmpty('runtimeClassName', $event)"
         />
       </div>
     </div>

--- a/edit/core.oam.dev.component/VerrazzanoWebLogicWorkload/ServerShutdown.vue
+++ b/edit/core.oam.dev.component/VerrazzanoWebLogicWorkload/ServerShutdown.vue
@@ -46,14 +46,14 @@ export default {
       <Checkbox
         :value="getField('ignoreSessions')"
         :mode="mode"
-        :label="t('verrazzano.VerrazzanoWebLogicWorkload.config.fields.serverPod.shutdown.ignoreSession')"
+        :label="t('verrazzano.weblogic.fields.serverPod.shutdown.ignoreSession')"
         @input="setBooleanField('ignoreSessions', $event)"
       />
       <div class="spacer-tiny" />
       <Checkbox
         :value="getField('waitForAllSessions')"
         :mode="mode"
-        :label="t('verrazzano.VerrazzanoWebLogicWorkload.config.fields.serverPod.shutdown.waitForAllSessions')"
+        :label="t('verrazzano.weblogic.fields.serverPod.shutdown.waitForAllSessions')"
         @input="setBooleanField('waitForAllSessions', $event)"
       />
     </div>
@@ -61,7 +61,7 @@ export default {
       <LabeledSelect
         :value="getField('shutdownType')"
         :mode="mode"
-        :label="t('verrazzano.VerrazzanoWebLogicWorkload.config.fields.serverPod.shutdown.shutdownType')"
+        :label="t('verrazzano.weblogic.fields.serverPod.shutdown.shutdownType')"
         :options="shutdownTypes"
         @input="setField('shutdownType', $event)"
       />
@@ -72,7 +72,7 @@ export default {
         :mode="mode"
         type="Number"
         min="0"
-        :label="t('verrazzano.VerrazzanoWebLogicWorkload.config.fields.serverPod.shutdown.timeoutSeconds')"
+        :label="t('verrazzano.weblogic.fields.serverPod.shutdown.timeoutSeconds')"
         @input="setNumberField('timeoutSeconds', $event)"
       />
     </div>

--- a/mixins/verrazzano/base-verrazzano-helper.js
+++ b/mixins/verrazzano/base-verrazzano-helper.js
@@ -227,7 +227,7 @@ export default {
       return !this.isView && Array.isArray(this.getListField(fieldName)) && this.getListField(fieldName).length > 0;
     },
     showEmptyListMessage(fieldName) {
-      return this.isView && Array.isArray(this.getListField(fieldName)) && this.getListField(fieldName).length.length === 0;
+      return this.isView && Array.isArray(this.getListField(fieldName)) && this.getListField(fieldName).length === 0;
     },
     didNamedObjectReallyChange(neu, old) {
       const neuIsEmpty = this.isEmpty(neu);

--- a/mixins/verrazzano/dynamic-list-helper.js
+++ b/mixins/verrazzano/dynamic-list-helper.js
@@ -1,6 +1,7 @@
 // Added by Verrazzano
 
 import { randomStr } from '~/utils/string';
+import debounce from 'lodash/debounce';
 import CreateEditView from '~/mixins/create-edit-view';
 
 export default {

--- a/mixins/verrazzano/dynamic-list-helper.js
+++ b/mixins/verrazzano/dynamic-list-helper.js
@@ -1,5 +1,6 @@
 // Added by Verrazzano
 
+import { isEmpty } from '@/utils/object';
 import { randomStr } from '~/utils/string';
 import debounce from 'lodash/debounce';
 import CreateEditView from '~/mixins/create-edit-view';
@@ -42,7 +43,9 @@ export default {
     addChild(child) {
       this.children.push({ _id: randomStr(4), ...child });
 
-      this.queueUpdate();
+      if (!isEmpty(child)) {
+        this.queueUpdate();
+      }
     },
     deleteChild(childToDelete) {
       const index = this.children.findIndex(child => child._id === childToDelete._id);

--- a/mixins/verrazzano/dynamic-list-helper.js
+++ b/mixins/verrazzano/dynamic-list-helper.js
@@ -1,9 +1,11 @@
 // Added by Verrazzano
 
 import { randomStr } from '~/utils/string';
-import debounce from 'lodash/debounce';
+import CreateEditView from '~/mixins/create-edit-view';
 
 export default {
+  mixins: [CreateEditView],
+
   data() {
     const rootFieldName = this.getRootFieldName();
 


### PR DESCRIPTION
Fixed aux images and environment variables in server pod.
Updated aux images to use dynamic-list-helper.
Cleaned up translations in server pod.
Remove dynamic-list-helper from individual server and cluster pages.
Avoid queue update when adding an empty child object.

*** translation changes on Helidon index.vue ***