### PR TITLE
VZ-6127: Include Verrazzano light and dark logos in _nuxt bundle

### DIFF
--- a/pkg/verrazzano/pages/index.vue
+++ b/pkg/verrazzano/pages/index.vue
@@ -30,16 +30,9 @@ export default {
     color: transparent;
     content: "\ea2a";
   }
-</style>
-
-// not used
-<style lang='scss'>
   .vzlight {
     background-image: url('../assets/images/verrazzano-light.svg');
   }
-</style>
-// not used
-<style lang='scss'>
   .vzdark {
     background-image: url('../assets/images/verrazzano-dark.svg');
   }

--- a/pkg/verrazzano/pages/index.vue
+++ b/pkg/verrazzano/pages/index.vue
@@ -40,7 +40,7 @@ export default {
 </style>
 // not used
 <style lang='scss'>
-  .vzlight {
+  .vzdark {
     background-image: url('../assets/images/verrazzano-dark.svg');
   }
 </style>

--- a/pkg/verrazzano/pages/index.vue
+++ b/pkg/verrazzano/pages/index.vue
@@ -31,3 +31,16 @@ export default {
     content: "\ea2a";
   }
 </style>
+
+// not used
+<style lang='scss'>
+  .vzlight {
+    background-image: url('../assets/images/verrazzano-light.svg');
+  }
+</style>
+// not used
+<style lang='scss'>
+  .vzlight {
+    background-image: url('../assets/images/verrazzano-dark.svg');
+  }
+</style>


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes #vz-6127
<!-- Define findings related to the feature or bug issue. -->
Settings `ui-logo-light` and `ui-logo-dark` needs to be populated with the base64 encoded value of corresponding logo svg's in a Verrazzano install in order to display the Verrazzano logo in Rancher Dashboard. This PR includes the logos in styles so that they are included in the `_nuxt` bundle.
### Occurred changes and/or fixed issues
<!-- Include information of the changes, including collateral areas which have been affected by this PR as requirement or for convenience. -->
The PR https://github.com/verrazzano/verrazzano/pull/4023 introduces the changes in main Verrazzano installation flow where the value of these settings will be populated. Basically we exec into the rancher pod containing these logos and populate the settings with base64 values.
### Technical notes summary
<!-- Outline technical changes which may pass unobserved or may help to understand the process of solving the issue -->
Another way to achieve is to copy these files in the _nuxt bundle in [build-embedded](https://github.com/verrazzano/rancher-dashboard/blob/oracle/release/2.6.7/scripts/build-embedded) script but then we have to change that code for every upgrade.
### Areas or cases that should be tested
<!-- Areas that should be tested can include Airgap checks, Rancher upgrades, K8s upgrade, etc. -->
<!-- Which browser did you use for local testing? The reviewer should test with a different browser. -->
<!-- Add missing steps or rewrite them if have been missed or to complement existing information. This should define a clear way to reproduce it and not an approximation. -->

### Areas which could experience regressions
<!-- Create a detailed list of areas to be analyzed which may be affected by the changes, which would require a prior research to avoid regressions. -->

### Screenshot/Video
<!-- Attach screenshot or video of the changes and eventual comparison if you find it necessary -->