### PR TITLE
Parameterize build to allow selection of Rancher version

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -81,12 +81,9 @@ pipeline {
 
         stage('Call Downstream Job') {
             when {
-                allOf {
-                    branch "oracle/release/*"
-                    anyOf {
-                        triggeredBy 'TimerTrigger'
-                        expression { return params.RANCHER_UPSTREAM_VERSION }
-                    }
+                anyOf {
+                    triggeredBy 'TimerTrigger'
+                    expression { return params.RANCHER_UPSTREAM_VERSION }
                 }
             }
             steps {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -87,12 +87,12 @@ pipeline {
                 }
             }
             steps {
-                build job: "Build from Source/rancher/oracle%2Frelease%2F"+${params.RANCHER_UPSTREAM_VERSION},
-                        propagate: false,
-                        wait: false,
-                        parameters: [
-                                string(name: "CATTLE_DASHBOARD_TAR_URL", value: "${OCI_OS_BUILD_URL}/rancher-dashboard%2F${env.TAR_FILE_NAME}")
-                        ]
+                build job: "Build from Source/rancher/oracle%2Frelease%2F${params.RANCHER_UPSTREAM_VERSION}",
+                    propagate: false,
+                    wait: false,
+                    parameters: [
+                        string(name: "CATTLE_DASHBOARD_TAR_URL", value: "${OCI_OS_BUILD_URL}/rancher-dashboard%2F${env.TAR_FILE_NAME}")
+                    ]
             }
         }
     }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -18,6 +18,16 @@ pipeline {
         cron( env.BRANCH_NAME.equals('oracle/release/2.6.7') ? 'H H(0-3) * * 1-5' : '')
     }
 
+    parameters {
+        string (name: 'RANCHER_UPSTREAM_VERSION',
+                defaultValue: '2.6.7',
+                description: 'Verrazzano Rancher upstream version to build, default 2.6.7',
+                trim: true)
+
+        booleanParam (name: 'TRIGGER_UPSTREAM', defaultValue: false,
+                description: 'Trigger the build for Verrazzano Rancher, similar to nightly build.')
+    }
+
     environment {
         DASHBOARD_VERSION = "2.6.7"
         OCI_CLI_AUTH = "instance_principal"
@@ -73,11 +83,14 @@ pipeline {
             when {
                 allOf {
                     branch "oracle/release/*"
-                    triggeredBy 'TimerTrigger'
+                    anyOf {
+                        triggeredBy 'TimerTrigger'
+                        expression { return params.RANCHER_UPSTREAM_VERSION }
+                    }
                 }
             }
             steps {
-                build job: "Build from Source/rancher/oracle%2Frelease%2F2.6.7", propagate: false, parameters: [
+                build job: "Build from Source/rancher/oracle%2Frelease%2F"+${params.RANCHER_UPSTREAM_VERSION}, propagate: false, parameters: [
                     string(name: "CATTLE_DASHBOARD_TAR_URL", value: "${OCI_OS_BUILD_URL}/rancher-dashboard%2F${env.TAR_FILE_NAME}")
                 ]
             }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -83,13 +83,16 @@ pipeline {
             when {
                 anyOf {
                     triggeredBy 'TimerTrigger'
-                    expression { return params.RANCHER_UPSTREAM_VERSION }
+                    expression { return params.TRIGGER_UPSTREAM }
                 }
             }
             steps {
-                build job: "Build from Source/rancher/oracle%2Frelease%2F"+${params.RANCHER_UPSTREAM_VERSION}, propagate: false, parameters: [
-                    string(name: "CATTLE_DASHBOARD_TAR_URL", value: "${OCI_OS_BUILD_URL}/rancher-dashboard%2F${env.TAR_FILE_NAME}")
-                ]
+                build job: "Build from Source/rancher/oracle%2Frelease%2F"+${params.RANCHER_UPSTREAM_VERSION},
+                        propagate: false,
+                        wait: false,
+                        parameters: [
+                                string(name: "CATTLE_DASHBOARD_TAR_URL", value: "${OCI_OS_BUILD_URL}/rancher-dashboard%2F${env.TAR_FILE_NAME}")
+                        ]
             }
         }
     }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -20,8 +20,8 @@ pipeline {
 
     parameters {
         string (name: 'RANCHER_UPSTREAM_VERSION',
-                defaultValue: '2.6.7',
-                description: 'Verrazzano Rancher upstream version to build, default 2.6.7',
+                defaultValue: '2.6.8',
+                description: 'Verrazzano Rancher upstream version to build, default 2.6.8',
                 trim: true)
 
         booleanParam (name: 'TRIGGER_UPSTREAM', defaultValue: false,


### PR DESCRIPTION
Allow the developer to select which upstream version of Rancher to build, and allow the developer to ability to trigger the upstream build for development purposes.  Currently, the upstream version is fixed, and only the nightly build can trigger an inclusion of the dashboard in the upstream Rancher build.