### PR TITLE
Correct spelling of Argo CD Console link

### DIFF
--- a/pkg/verrazzano/l10n/en-us.yaml
+++ b/pkg/verrazzano/l10n/en-us.yaml
@@ -1441,7 +1441,7 @@ verrazzano:
   ### verrazzano.links ###
   ########################
   links:
-    argoCDUrl: ArgoCD Console
+    argoCDUrl: Argo CD Console
     consoleUrl: Verrazzano Console
     docs: Docs
     fileAnIssue: File an Issue


### PR DESCRIPTION
Change the spelling of the Argo console link from "ArgoCD" to "Argo CD".