### PR TITLE
VZ-9717: remove "hosted" from cluster creation screen

### DIFF
--- a/shell/assets/translations/en-us.yaml
+++ b/shell/assets/translations/en-us.yaml
@@ -1770,7 +1770,7 @@ cluster:
   providerGroup:
     create-custom1: Use existing nodes and create a cluster using RKE
     create-custom2: Use existing nodes and create a cluster using RKE2/K3s
-    create-kontainer: Create a cluster in a hosted Kubernetes provider
+    create-kontainer: Create a cluster in a Kubernetes provider
     register-kontainer: Register an existing cluster in a hosted Kubernetes provider
     create-rke1: Provision new nodes and create a cluster using RKE
     create-rke2: Provision new nodes and create a cluster using RKE2/K3s

--- a/shell/assets/translations/en-us.yaml
+++ b/shell/assets/translations/en-us.yaml
@@ -1771,6 +1771,7 @@ cluster:
     create-custom1: Use existing nodes and create a cluster using RKE
     create-custom2: Use existing nodes and create a cluster using RKE2/K3s
     # Added by Verrazzano Start
+    # create-kontainer: Create a cluster in a hosted Kubernetes provider
     create-kontainer: Create a cluster in a Kubernetes provider
     # Added by Verrazzano End
     register-kontainer: Register an existing cluster in a hosted Kubernetes provider

--- a/shell/assets/translations/en-us.yaml
+++ b/shell/assets/translations/en-us.yaml
@@ -1770,7 +1770,9 @@ cluster:
   providerGroup:
     create-custom1: Use existing nodes and create a cluster using RKE
     create-custom2: Use existing nodes and create a cluster using RKE2/K3s
+    # Added by Verrazzano Start
     create-kontainer: Create a cluster in a Kubernetes provider
+    # Added by Verrazzano End
     register-kontainer: Register an existing cluster in a hosted Kubernetes provider
     create-rke1: Provision new nodes and create a cluster using RKE
     create-rke2: Provision new nodes and create a cluster using RKE2/K3s


### PR DESCRIPTION
This PR removes the word "hosted" from the cluster creation screen where OCNE icon is shown.

### Screenshot
![Removed Host Screenshot](https://github.com/verrazzano/rancher-dashboard/assets/55011273/bb607cb1-1d08-4520-ad30-9d7c942a1f5a)
