### PR TITLE
Obtain state object from prov cluster instead of mgmt cluster for ocne

### DIFF
--- a/shell/models/provisioning.cattle.io.cluster.js
+++ b/shell/models/provisioning.cattle.io.cluster.js
@@ -267,6 +267,12 @@ export default class ProvCluster extends SteveModel {
     return !!this.mgmt?.spec?.rancherKubernetesEngineConfig;
   }
 
+  // Added by Verrazzano Start
+  get isOciOcne() {
+    return this.mgmt?.status?.driver === 'ociocne';
+  }
+  // Added by Verrazzano End
+
   get isHarvester() {
     return !!this.mgmt?.isHarvester;
   }
@@ -724,7 +730,10 @@ export default class ProvCluster extends SteveModel {
   }
 
   get _stateObj() {
-    if (!this.isRke2) {
+    // Added by Verrazzano Start
+    // if (!this.isRke2) {
+    if (!this.isRke2 && !this.isOciOcne) {
+    // Added by Verrazzano End
       return this.mgmt?.stateObj || this.metadata?.state;
     }
 


### PR DESCRIPTION
This PR will report ocne cluster state from the prov cluster instead of the mgmt cluster. This is in alignment with RKE2 clusters -- RKE1 clusters use the mgmt cluster state. Fixes VZ-10194
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes #
<!-- Define findings related to the feature or bug issue. -->

### Occurred changes and/or fixed issues
<!-- Include information of the changes, including collateral areas which have been affected by this PR as requirement or for convenience. -->

### Technical notes summary
<!-- Outline technical changes which may pass unobserved or may help to understand the process of solving the issue -->

### Areas or cases that should be tested
<!-- Areas that should be tested can include Airgap checks, Rancher upgrades, K8s upgrade, etc. -->
<!-- Which browser did you use for local testing? The reviewer should test with a different browser. -->

<!-- Add missing steps or rewrite them if have been missed or to complement existing information. This should define a clear way to reproduce it and not an approximation. -->

### Areas which could experience regressions
<!-- Create a detailed list of areas to be analyzed which may be affected by the changes, which would require a prior research to avoid regressions. -->

### Screenshot/Video
<!-- Attach screenshot or video of the changes and eventual comparison if you find it necessary -->