### PR TITLE
Update clusterNames property during @input

### DIFF
--- a/pkg/verrazzano/edit/clusters.verrazzano.io.multiclusterapplicationconfiguration/index.vue
+++ b/pkg/verrazzano/edit/clusters.verrazzano.io.multiclusterapplicationconfiguration/index.vue
@@ -84,6 +84,8 @@ export default {
       } else {
         this.setField('spec.placement.clusters', undefined);
       }
+
+      this.clusterNames = this.getListField('spec.placement.clusters').map(cluster => cluster.name);
     }
   },
   watch: {


### PR DESCRIPTION
ensure that the clusterNames property gets set during the LabeledInput's @input event