### PR TITLE
VZ-10372 Add the Thanos Ruler URL to the Dashboard

### DIFF
--- a/pkg/verrazzano/l10n/en-us.yaml
+++ b/pkg/verrazzano/l10n/en-us.yaml
@@ -1457,6 +1457,7 @@ verrazzano:
     prometheusUrl: Prometheus Console
     rancherUrl: Rancher Console
     thanosQueryUrl: Thanos Query
+    thanosRulerUrl: Thanos Ruler
     slack: Slack
     title: Verrazzano Links
 


### PR DESCRIPTION
New Verrazzano Link for Verrazzano: Thanos Ruler.

![image](https://github.com/verrazzano/rancher-dashboard/assets/49332517/1d8fef6c-d740-48fc-a918-aee2dd206474)
