### PR TITLE
Remove local object storage bucket names, they will pickup the defini…

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -26,7 +26,6 @@ pipeline {
         DASHBOARD_VERSION = "2.7.5"
         OCI_CLI_AUTH = "instance_principal"
         OCI_OS_NAMESPACE = credentials('oci-os-namespace')
-        OCI_OS_BUCKET = "verrazzano-builds"
         GITHUB_ACCESS_TOKEN = credentials('github-api-token-release-process')
     }
 


### PR DESCRIPTION
VZ-11409 We have more than one Jenkins running in parallel for OL8 Jenkins work (VZ-10212), we need jobs to use the new global env for the buckets instead of locally defining them (ie: the old and new Jenkins are using different buckets to avoid jobs running in parallel from stomping on each other while we test) 